### PR TITLE
Backend - Search for public user profiles via partial query match on firstName

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,3 +8,8 @@ To lint and run commands, run `npx eslint yourcommand`
 Additionally, for convenience, set up your default formatter to be ESlint
 
 To format, CTRL - SHIT - P -> ESLint: Fix all auto-fixable Problems
+
+Testing backend REST APIs
+curl -X GET localhost:3000/api/getUser -H 'Content-Type: application/json' -d '{"email": "shynnlawrence@gmail.com"}' -v
+
+curl -X POST lGET localhost:3000/api/getUser -H 'POST localhost:3000/api/updateUser -H 'Content-Type: application/json' -d '{"email": "shynnlawrence@gmail.com", "firstName": "Shynn", "lastName": "Lawrence", "session": "c45e71ff-313f-4ddd-a990-774d9c4380ff", "other_info": {"instagram": "shua1008", "discord": "shua1008"}}' -v

--- a/database/index.ts
+++ b/database/index.ts
@@ -8,7 +8,8 @@ import {
   addDoc,
   doc,
   setDoc,
-  getFirestore
+  getFirestore,
+  and
 } from 'firebase/firestore/lite'
 import { getStorage } from 'firebase/storage'
 import { type User } from '@/pages/api/types/user'
@@ -50,6 +51,23 @@ class UserDBManager {
     const usersCol = collection(this.db, 'users')
     const userSnapshot = await getDocs(usersCol)
     const users = userSnapshot.docs.map((doc) => doc.data())
+    return users
+  }
+
+  async getUsersFiltered (firstNameFilter: string) {
+    const usersCol = collection(this.db, 'users')
+    // Yeah it's weird, don't question it; this is equivalent to startsWith
+    const firstNameEnd = firstNameFilter.split('').map((val, ind) => ((ind === firstNameFilter.length - 1) ? String.fromCharCode(val.charCodeAt(0) + 1) : val)).join('')
+    const q = query(usersCol, and(where('firstName', '>=', firstNameFilter), where('firstName', '<', firstNameEnd)))
+    const userSnapshot = await getDocs(q)
+    const users: Array<User | null> = userSnapshot.docs.map((doc) => {
+      const u = doc.data() as User
+      if (u.other_info?.important) {
+        return u
+      } else {
+        return null
+      }
+    }).filter((val) => (val))
     return users
   }
 

--- a/pages/api/getUser.ts
+++ b/pages/api/getUser.ts
@@ -1,5 +1,7 @@
+// For use in user profile modification (changing your own details),
+// this will be useful to fill a given user's current details, which
+// they can just edit later on
 import { type NextApiRequest, type NextApiResponse } from 'next'
-import contactManager from '../../database/ContactManager'
 import userManager from '../../database/index'
 import verifyUser from './utils/verifyUser'
 
@@ -23,26 +25,7 @@ export default async function handler (
     if (u === null) {
       res.status(403).json({ message: 'Errored out getting user by passed-in email' })
     } else {
-      // If index isn't a number, convert it to one
-      if (typeof req.body.index !== 'number') {
-        req.body.index = parseInt(req.body.index)
-      }
-      let contacts = await contactManager.getContacts(u.id)
-      if (req.body.index !== null && req.body.index !== undefined) {
-        if (req.body.index <= contacts.length) {
-          res.status(200).json({ contacts: contacts[req.body.index] })
-          return
-        }
-        if (req.body.important === true) {
-          contacts = contacts.filter((c: { important: boolean }) => c.important)
-        }
-        if (req.body.search) {
-          contacts = contacts.filter(
-            (c: { firstName: string, lastName: string }) => (c.firstName.toLowerCase() + ' ' + c.lastName.toLowerCase()).includes(req.body.search.toLowerCase())
-          )
-        }
-        res.status(200).json({ contacts })
-      }
+      res.status(400).json(u)
     }
   } catch (error) {
     console.log(`Error in addContacts: ${error as string}`)


### PR DESCRIPTION
If I want to search for all public profiles starting with Bri (ex: Brian, Brianna, etc), I can now do that! Frontend will use this so that autofill can find public profiles when people start typing (they have to type the beginning characters of a firstName which corresponds to a public user whose firstName starts with those characters.
Example:
For query:
![image](https://github.com/shua1090/caltact/assets/61219106/127857bd-0a11-4e03-8515-3b64f1a8f09e)
Result:
![image](https://github.com/shua1090/caltact/assets/61219106/bd3493ac-c387-4c4e-890f-c0e9f6559445)
With Database entries:
![image](https://github.com/shua1090/caltact/assets/61219106/8a5a9131-826b-4a80-804c-7539486cdf9f)
![image](https://github.com/shua1090/caltact/assets/61219106/f8134fd5-115f-4d33-95fd-46ca85854388)
(Brianna Mainly, ignore the uncreative naming I just made it up nearing midnight, doesn't have an important field (or if it were false, same idea), so she didn't make the cut (i.e. her profile isn't public/'important')
